### PR TITLE
fix: 添加 shared/ 目录到 package.json files 字段

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist/",
     "docs/",
     "server/",
+    "shared/",
     ".env.local.example",
     "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",


### PR DESCRIPTION
## 问题描述

通过 `npm install -g lalaclaw` 安装后无法启动，报错缺少模块文件。

```
Error: Cannot find module '../../shared/strip-markdown-for-display.cjs'
```

## 根本原因

`package.json` 的 `files` 字段缺少 `"shared/"` 目录，导致发布到 npm 的包不完整。

## 变更内容

在 `package.json` 的 `files` 字段中添加 `"shared/"`：

```json
"files": [
  "bin/",
  "dist/",
  "docs/",
  "server/",
  "shared/",    ← 添加这一行
  ...
]
```

## 测试

- [x] 源码版本正常运行（包含 shared/ 目录）
- [ ] npm 包版本需要发布后验证

## 影响范围

修复所有通过 `npm install -g lalaclaw` 安装的用户无法启动的问题。

---

谢谢！🙏