### PR TITLE
feat: support CLI help/version aliases and Windows runtime overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows-style `file:///C:/...` markdown image links now resolve through local file preview URLs correctly in chat rendering
+- Added cross-platform runtime overrides for `lalaclaw dev/frontend/backend` so Windows can start services with `--host/--port` flags instead of POSIX-only `HOST=... PORT=...` prefix syntax
+- Added CLI aliases `-h`/`--help` for help output and `-v`/`--version` for version output
+
 ## [2026.3.17-9]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,9 +155,18 @@ npm run lalaclaw:start
 
 ## Common Commands
 
-- `npm run dev:all` starts the standard local development workflow
+- `npm run dev` starts the Vite development server
+- `npm run dev:all` starts both the frontend and backend in development mode
+- `npm run dev:frontend` starts only the Vite development server
+- `npm run dev:backend` starts only the backend server
+- Runtime commands accept overrides like `--host`, `--port`, `--frontend-host`, `--frontend-port`, and `--profile` (for example: `npm run dev:backend -- --host 127.0.0.1 --port 3000`)
 - `npm run doctor` checks Node.js, OpenClaw discovery, ports, and local config
-- `npm run lalaclaw:init` writes or refreshes local bootstrap config
+  For `remote-gateway`, it also probes the configured gateway URL and sends a minimal API request to validate the configured model and agent.
+- `npm run doctor -- --fix` installs LibreOffice automatically on macOS when LibreOffice-backed preview support is missing
+- `npm run doctor -- --json` prints the same diagnosis as machine-readable JSON with `summary.status` and `summary.exitCode`
+- `npm run lalaclaw:init` writes a local `.env.local` bootstrap file
+- `lalaclaw -h` / `lalaclaw --help` prints CLI help, and `lalaclaw -v` / `lalaclaw --version` prints the current CLI version
+- `npm run lalaclaw:init -- --write-example` copies [`.env.local.example`](./.env.local.example) to your target config path without prompts
 - `npm run lalaclaw:start` starts the built app after checking `dist/`
 - `npm run build` creates the production bundle
 - `npm test` runs the Vitest suite once

--- a/bin/lalaclaw.js
+++ b/bin/lalaclaw.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const path = require('node:path');
 const readline = require('node:readline/promises');
 const { spawn, spawnSync } = require('node:child_process');
+const { version: PACKAGE_VERSION } = require('../package.json');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 const DEFAULT_HOST = '127.0.0.1';
@@ -95,10 +96,10 @@ Usage:
   lalaclaw status
   lalaclaw stop
   lalaclaw restart
-  lalaclaw dev [--config-file <path>]
-  lalaclaw start [--config-file <path>]
-  lalaclaw frontend [--config-file <path>]
-  lalaclaw backend [--config-file <path>]
+  lalaclaw dev [--config-file <path>] [--host <host>] [--port <port>] [--frontend-host <host>] [--frontend-port <port>] [--profile <name>]
+  lalaclaw start [--config-file <path>] [--host <host>] [--port <port>] [--profile <name>]
+  lalaclaw frontend [--config-file <path>] [--frontend-host <host>] [--frontend-port <port>]
+  lalaclaw backend [--config-file <path>] [--host <host>] [--port <port>] [--profile <name>]
 
 Commands:
   init      Create or refresh local config, then start Server and Frontend in the background when available.
@@ -122,6 +123,16 @@ function parseArgs(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
+    if (token === '-h' || token === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    if (token === '-v' || token === '--version') {
+      options.version = true;
+      continue;
+    }
+
     if (!token.startsWith('--')) {
       args.push(token);
       continue;
@@ -160,11 +171,6 @@ function parseArgs(argv) {
       const key = OPTION_ALIASES[token];
       options[key] = key === 'configFile' ? path.resolve(process.cwd(), value) : value;
       index += 1;
-      continue;
-    }
-
-    if (token === '--help' || token === '-h') {
-      options.help = true;
       continue;
     }
 
@@ -1571,10 +1577,10 @@ async function startInitBackgroundServer(envFilePath) {
 }
 
 
-function buildChildEnv(envFilePath) {
+function buildChildEnv(envFilePath, overrides = {}) {
   const envValues = readEnvFile(envFilePath);
   const localOpenClaw = detectLocalOpenClaw();
-  const config = resolveConfig(envValues, localOpenClaw);
+  const config = applyConfigOverrides(resolveConfig(envValues, localOpenClaw), overrides);
   const childEnv = {
     ...process.env,
     HOST: config.host,
@@ -1663,9 +1669,9 @@ function stopChild(child) {
   child.kill('SIGTERM');
 }
 
-async function runFrontend(envFilePath) {
+async function runFrontend(envFilePath, options = {}) {
   ensureDevelopmentAssetsAvailable();
-  const { childEnv, config } = buildChildEnv(envFilePath);
+  const { childEnv, config } = buildChildEnv(envFilePath, options);
   await ensurePortAvailable('Frontend port', config.frontendHost, config.frontendPort);
   console.log(`INFO  Starting frontend at http://${config.frontendHost}:${config.frontendPort}`);
   const child = runChild(
@@ -1679,8 +1685,8 @@ async function runFrontend(envFilePath) {
   });
 }
 
-async function runBackend(envFilePath) {
-  const { childEnv, config } = buildChildEnv(envFilePath);
+async function runBackend(envFilePath, options = {}) {
+  const { childEnv, config } = buildChildEnv(envFilePath, options);
   await ensurePortAvailable('Backend port', config.host, config.backendPort);
   console.log(`INFO  Starting backend at http://${config.host}:${config.backendPort} in ${config.profile} mode`);
   const child = runChild(process.execPath, ['server.js'], childEnv);
@@ -1690,9 +1696,9 @@ async function runBackend(envFilePath) {
   });
 }
 
-async function runDev(envFilePath) {
+async function runDev(envFilePath, options = {}) {
   ensureDevelopmentAssetsAvailable();
-  const { childEnv, config } = buildChildEnv(envFilePath);
+  const { childEnv, config } = buildChildEnv(envFilePath, options);
   await ensurePortAvailable('Frontend port', config.frontendHost, config.frontendPort);
   await ensurePortAvailable('Backend port', config.host, config.backendPort);
   const frontend = runChild(
@@ -1724,8 +1730,8 @@ async function runDev(envFilePath) {
   backend.on('exit', (code) => shutdown(typeof code === 'number' ? code : 0));
 }
 
-async function runStart(envFilePath) {
-  const { childEnv, config } = buildChildEnv(envFilePath);
+async function runStart(envFilePath, options = {}) {
+  const { childEnv, config } = buildChildEnv(envFilePath, options);
 
   if (!fs.existsSync(DIST_DIR)) {
     throw new Error(
@@ -1796,6 +1802,11 @@ async function main() {
   const { command, options } = parseArgs(process.argv.slice(2));
   const envFilePath = options.configFile || DEFAULT_ENV_FILE;
 
+  if (options.version) {
+    console.log(PACKAGE_VERSION);
+    return;
+  }
+
   if (options.help || command === 'help') {
     printHelp();
     return;
@@ -1842,22 +1853,22 @@ async function main() {
   }
 
   if (command === 'dev') {
-    await runDev(envFilePath);
+    await runDev(envFilePath, options);
     return;
   }
 
   if (command === 'start') {
-    await runStart(envFilePath);
+    await runStart(envFilePath, options);
     return;
   }
 
   if (command === 'frontend') {
-    await runFrontend(envFilePath);
+    await runFrontend(envFilePath, options);
     return;
   }
 
   if (command === 'backend') {
-    await runBackend(envFilePath);
+    await runBackend(envFilePath, options);
     return;
   }
 
@@ -1875,6 +1886,7 @@ module.exports = {
   DEFAULT_AGENT_ID,
   REQUIRED_NODE_MAJOR,
   PACKAGE_NAME,
+  PACKAGE_VERSION,
   LEGACY_ENV_FILE,
   DEFAULT_CONFIG_DIR,
   EXAMPLE_ENV_FILE,

--- a/docs/en/documentation-quick-start.md
+++ b/docs/en/documentation-quick-start.md
@@ -143,7 +143,7 @@ For normal repository development, use the fixed dev ports defined by the repo:
 
 ```bash
 npm run dev -- --host 127.0.0.1 --port 5173 --strictPort
-PORT=3000 HOST=127.0.0.1 node server.js
+npm run dev:backend -- --host 127.0.0.1 --port 3000
 ```
 
 You can also start both processes with:
@@ -223,7 +223,7 @@ On startup, the backend first tries to read local OpenClaw config from `~/.openc
 Force `mock` mode:
 
 ```bash
-COMMANDCENTER_FORCE_MOCK=1 PORT=3000 HOST=127.0.0.1 node server.js
+npm run dev:backend -- --profile mock --host 127.0.0.1 --port 3000
 ```
 
 If you use the CLI to initialize config:

--- a/docs/zh/documentation-quick-start.md
+++ b/docs/zh/documentation-quick-start.md
@@ -143,7 +143,7 @@ npm run lalaclaw:start
 
 ```bash
 npm run dev -- --host 127.0.0.1 --port 5173 --strictPort
-PORT=3000 HOST=127.0.0.1 node server.js
+npm run dev:backend -- --host 127.0.0.1 --port 3000
 ```
 
 你也可以直接运行：
@@ -223,7 +223,7 @@ tail -f ./logs/lalaclaw-launchd.err.log
 强制使用 `mock`：
 
 ```bash
-COMMANDCENTER_FORCE_MOCK=1 PORT=3000 HOST=127.0.0.1 node server.js
+npm run dev:backend -- --profile mock --host 127.0.0.1 --port 3000
 ```
 
 如果你使用 CLI 初始化配置：

--- a/src/components/command-center/chat-panel.test.jsx
+++ b/src/components/command-center/chat-panel.test.jsx
@@ -479,6 +479,43 @@ describe("ChatPanel", () => {
     );
   });
 
+
+
+  it("renders markdown images with Windows file URLs inside user messages", async () => {
+    render(
+      <TooltipProvider>
+        <ChatPanel
+          busy={false}
+          formatTime={() => "10:00:00"}
+          messageViewportRef={{ current: null }}
+          messages={[
+            {
+              id: "msg-user-markdown-image-windows",
+              role: "user",
+              content: "![image](file:///C:/Users/marila/openclaw/workspace/media/inbound/demo.jpg)",
+              timestamp: 1,
+            },
+          ]}
+          onChatFontSizeChange={() => {}}
+          onPromptChange={() => {}}
+          onPromptKeyDown={() => {}}
+          onReset={() => {}}
+          onSend={() => {}}
+          prompt=""
+          promptRef={null}
+          resolvedTheme="dark"
+          session={createSession()}
+        />
+      </TooltipProvider>,
+    );
+
+    const image = await screen.findByAltText("image");
+    expect(image).toBeInTheDocument();
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/file-preview/content?path=C%3A%2FUsers%2Fmarila%2Fopenclaw%2Fworkspace%2Fmedia%2Finbound%2Fdemo.jpg",
+    );
+  });
   it.each(["[图片]", "[image]", "[Image]"])(
     "hides the DingTalk image placeholder label %s when a markdown image follows it",
     async (placeholder) => {

--- a/src/components/command-center/markdown-renderer.jsx
+++ b/src/components/command-center/markdown-renderer.jsx
@@ -298,11 +298,17 @@ function resolveMarkdownImagePath(src = "", files = []) {
     try {
       const fileUrl = new URL(normalizedSrc);
       const filePath = decodeURIComponent(fileUrl.pathname || "");
-      return /^\/[A-Za-z]:\//.test(filePath) ? filePath.slice(1) : filePath;
+      if (/^\/[A-Za-z]:\//.test(filePath)) {
+        return filePath.slice(1);
+      }
+      if (fileUrl.host) {
+        return `\\\\${fileUrl.host}${filePath.replace(/\//g, "\\")}`;
+      }
+      return filePath;
     } catch {}
   }
 
-  if (/^\/(Users|tmp|private|var|home|mnt|opt|Volumes|Library)\b/.test(normalizedSrc)) {
+  if (/^\/(Users|tmp|private|var|home|mnt|opt|Volumes|Library)\b/.test(normalizedSrc) || /^[A-Za-z]:[\\/]/.test(normalizedSrc) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(normalizedSrc)) {
     return normalizedSrc;
   }
 
@@ -343,7 +349,7 @@ function markdownUrlTransform(url = "") {
     return normalizedUrl;
   }
 
-  if (/^\/(Users|tmp|private|var|home|mnt|opt|Volumes|Library)\b/.test(normalizedUrl)) {
+  if (/^\/(Users|tmp|private|var|home|mnt|opt|Volumes|Library)\b/.test(normalizedUrl) || /^[A-Za-z]:[\\/]/.test(normalizedUrl) || /^\\\\[^\\/]+[\\/][^\\/]+/.test(normalizedUrl)) {
     return normalizedUrl;
   }
 

--- a/test/lalaclaw-cli.test.js
+++ b/test/lalaclaw-cli.test.js
@@ -27,6 +27,20 @@ describe("LalaClaw CLI helpers", () => {
     expect(parsed.options.fix).toBe(true);
   });
 
+
+
+  it("supports -h/--help aliases", () => {
+    expect(cli.parseArgs(["-h"]).options.help).toBe(true);
+    expect(cli.parseArgs(["--help"]).options.help).toBe(true);
+  });
+
+  it("supports -v/--version aliases", () => {
+    expect(cli.parseArgs(["-v"]).options.version).toBe(true);
+    expect(cli.parseArgs(["--version"]).options.version).toBe(true);
+    expect(typeof cli.PACKAGE_VERSION).toBe("string");
+    expect(cli.PACKAGE_VERSION.length).toBeGreaterThan(0);
+  });
+
   it("parses status and stop commands without extra options", () => {
     expect(cli.parseArgs(["status"]).command).toBe("status");
     expect(cli.parseArgs(["stop"]).command).toBe("stop");
@@ -239,6 +253,28 @@ describe("LalaClaw CLI helpers", () => {
     expect(nextConfig.openclawApiPath).toBe("/v1/responses");
   });
 
+
+
+  it("applies host/port/profile overrides for runtime commands", () => {
+    const { childEnv, config } = cli.buildChildEnv(
+      "/tmp/does-not-exist.env",
+      {
+        host: "0.0.0.0",
+        backendPort: "3300",
+        frontendPort: "5300",
+        profile: "mock",
+      },
+    );
+
+    expect(config.host).toBe("0.0.0.0");
+    expect(config.backendPort).toBe("3300");
+    expect(config.frontendPort).toBe("5300");
+    expect(config.profile).toBe("mock");
+    expect(childEnv.HOST).toBe("0.0.0.0");
+    expect(childEnv.PORT).toBe("3300");
+    expect(childEnv.FRONTEND_PORT).toBe("5300");
+    expect(childEnv.COMMANDCENTER_FORCE_MOCK).toBe("1");
+  });
   it("renders an env file for mock mode with stable defaults", () => {
     const output = cli.renderEnvFile({
       host: "127.0.0.1",


### PR DESCRIPTION
## Summary
- carry forward the changes from #20 onto current `main`
- add `-h`/`--help` and `-v`/`--version` aliases to `lalaclaw`
- support cross-platform `--host`/`--port`/`--frontend-host`/`--frontend-port`/`--profile` overrides for runtime commands
- fix Windows-style `file:///C:/...` markdown image links in chat rendering

## Notes
- this PR supersedes the merge path for #20 by resolving the current conflicts against `main`
- `start` now also applies the documented runtime overrides so the help text matches actual behavior

## Validation
- `npm test -- test/lalaclaw-cli.test.js`
- `npm test -- src/components/command-center/chat-panel.test.jsx`