### PR TITLE
feat: polish command center composer and inspector UX

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,9 @@ const desktopBreakpointQuery = "(min-width: 1280px)";
 const dragHandleWidth = 8;
 const resizeHandleDots = Array.from({ length: 12 });
 const minChatPanelWidth = 560;
+const compactInspectorPanelMinWidth = 58;
+const compactInspectorPanelMaxWidth = 72;
+const compactChatPanelMinWidth = 220;
 
 function getRelationshipDisplay(relationship, messages) {
   const fallbackLabel =
@@ -437,7 +440,9 @@ function AppContent() {
     handleSearchSessions,
     handlePromptChange,
     handlePromptKeyDown,
+    handleClearQueuedMessages,
     handleRemoveAttachment,
+    handleRemoveQueuedMessage,
     handleReset,
     handleSend,
     handleSelectSearchedSession,
@@ -452,6 +457,7 @@ function AppContent() {
     inspectorPanelWidth,
     peeks,
     prompt,
+    promptSyncVersion,
     promptRef,
     renderPeek,
     resolvedTheme,
@@ -503,6 +509,23 @@ function AppContent() {
     const nextWidth = Number.isFinite(numericWidth) ? numericWidth : fallbackWidth;
     return Math.round(Math.min(maximumWidth, Math.max(minimumWidth, nextWidth)));
   }, [getInspectorPanelWidthBounds, splitLayoutWidth]);
+
+  const getCompactInspectorPanelWidth = useCallback((containerWidth = splitLayoutWidth) => {
+    if (!Number.isFinite(containerWidth) || containerWidth <= 0) {
+      return 64;
+    }
+
+    const desiredWidth = 64;
+    const maximumWidth = Math.max(
+      compactInspectorPanelMinWidth,
+      Math.min(compactInspectorPanelMaxWidth, containerWidth - compactChatPanelMinWidth),
+    );
+
+    return Math.max(
+      compactInspectorPanelMinWidth,
+      Math.min(maximumWidth, desiredWidth),
+    );
+  }, [splitLayoutWidth]);
 
   const stopPanelResize = () => {
     resizeCleanupRef.current?.();
@@ -612,13 +635,19 @@ function AppContent() {
     () => getClampedInspectorPanelWidth(inspectorPanelWidth),
     [getClampedInspectorPanelWidth, inspectorPanelWidth],
   );
-  const desktopLayoutStyle = useMemo(
+  const compactInspectorPanelWidth = useMemo(
+    () => getCompactInspectorPanelWidth(splitLayoutWidth),
+    [getCompactInspectorPanelWidth, splitLayoutWidth],
+  );
+  const splitLayoutStyle = useMemo(
     () => (isWideLayout
       ? {
           gridTemplateColumns: `minmax(0, 1fr) ${dragHandleWidth}px ${resolvedInspectorPanelWidth}px`,
         }
-      : undefined),
-    [isWideLayout, resolvedInspectorPanelWidth],
+      : {
+          gridTemplateColumns: `minmax(0, 1fr) ${compactInspectorPanelWidth}px`,
+        }),
+    [compactInspectorPanelWidth, isWideLayout, resolvedInspectorPanelWidth],
   );
   const openAgentIds = useMemo(() => chatTabs.map((tab) => tab.agentId), [chatTabs]);
   const tabBrandOverview = useMemo(() => (
@@ -788,6 +817,7 @@ function AppContent() {
       activeTab={activeTab}
       agents={agents}
       artifacts={artifacts}
+      compact={!isWideLayout}
       currentAgentId={session.agentId}
       currentSessionUser={session.sessionUser}
       currentWorkspaceRoot={session.workspaceRoot}
@@ -806,6 +836,7 @@ function AppContent() {
     artifacts,
     files,
     handleArtifactSelect,
+    isWideLayout,
     peeks,
     renderPeek,
     resolvedTheme,
@@ -820,11 +851,11 @@ function AppContent() {
   return (
     <TooltipProvider delayDuration={150}>
       <div
-        className="min-h-dvh bg-background text-foreground xl:h-dvh xl:overflow-hidden"
+        className="h-dvh overflow-hidden bg-background text-foreground"
         aria-busy={switchingAgentOverlay || switchingModelOverlay ? "true" : "false"}
       >
-        <div className="mx-auto flex min-h-dvh w-full max-w-[1760px] flex-col gap-2 overflow-y-auto px-3 py-3 xl:h-full xl:min-h-0 xl:overflow-hidden">
-          <div className="flex items-center justify-between gap-3">
+        <div className="mx-auto flex h-full min-h-0 w-full max-w-[1760px] flex-col gap-2 overflow-hidden px-3 py-3">
+          <div className="flex shrink-0 items-center justify-between gap-3">
             <div className="min-w-0 flex-1">
               <ChatTabsStrip
                 className="min-w-0 pt-0 pb-0 pr-0"
@@ -843,10 +874,10 @@ function AppContent() {
 
           <main
             ref={splitLayoutRef}
-            className="grid content-start gap-3 xl:min-h-0 xl:flex-1 xl:grid-rows-[minmax(0,1fr)] xl:gap-0 xl:overflow-hidden"
-            style={desktopLayoutStyle}
+            className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] overflow-hidden"
+            style={splitLayoutStyle}
           >
-            <div className="xl:min-h-0 xl:pr-0.5">
+            <div className="min-h-0 min-w-0 pr-1.5 xl:pr-0.5">
               <ChatPanel
                 agentLabel={session.agentLabel || session.agentId || "main"}
                 activeChatTabId={activeChatTabId}
@@ -871,10 +902,13 @@ function AppContent() {
                 onRemoveAttachment={handleRemoveAttachment}
                 onPromptChange={handlePromptChange}
                 onPromptKeyDown={handlePromptKeyDown}
+                onClearQueuedMessages={handleClearQueuedMessages}
+                onRemoveQueuedMessage={handleRemoveQueuedMessage}
                 onReset={() => handleReset().catch(() => {})}
                 onSend={handleSend}
                 onStop={() => handleStop().catch(() => {})}
                 prompt={prompt}
+                promptSyncVersion={promptSyncVersion}
                 promptRef={promptRef}
                 resolvedTheme={resolvedTheme}
                 restoredScrollKey={restoredChatScrollKey}
@@ -887,38 +921,40 @@ function AppContent() {
               />
             </div>
 
-            <div className="hidden xl:flex xl:min-h-0 xl:items-stretch xl:justify-center">
-              <button
-                type="button"
-                aria-label={i18nMessages.common.resizePanels}
-                onPointerDown={handleResizeStart}
-                className="group relative h-full w-full cursor-col-resize touch-none select-none"
-              >
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    "absolute left-1/2 top-1/2 inline-grid h-[22px] w-[6.8px] -translate-x-1/2 -translate-y-1/2 grid-cols-2 grid-rows-6 gap-x-[2px] gap-y-[2px] transition-colors",
-                    isResizingPanels
-                      ? "bg-transparent"
-                      : "bg-transparent",
-                  )}
+            {isWideLayout ? (
+              <div className="xl:flex xl:min-h-0 xl:items-stretch xl:justify-center">
+                <button
+                  type="button"
+                  aria-label={i18nMessages.common.resizePanels}
+                  onPointerDown={handleResizeStart}
+                  className="group relative h-full w-full cursor-col-resize touch-none select-none"
                 >
-                  {resizeHandleDots.map((_, index) => (
-                    <span
-                      key={index}
-                      className={cn(
-                        "h-[2.4px] w-[2.4px] rounded-full transition-colors",
-                        isResizingPanels ? "bg-primary/80" : "bg-muted-foreground/45 group-hover:bg-foreground/55",
-                      )}
-                    />
-                  ))}
-                </span>
-              </button>
-            </div>
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "absolute left-1/2 top-1/2 inline-grid h-[22px] w-[6.8px] -translate-x-1/2 -translate-y-1/2 grid-cols-2 grid-rows-6 gap-x-[2px] gap-y-[2px] transition-colors",
+                      isResizingPanels
+                        ? "bg-transparent"
+                        : "bg-transparent",
+                    )}
+                  >
+                    {resizeHandleDots.map((_, index) => (
+                      <span
+                        key={index}
+                        className={cn(
+                          "h-[2.4px] w-[2.4px] rounded-full transition-colors",
+                          isResizingPanels ? "bg-primary/80" : "bg-muted-foreground/45 group-hover:bg-foreground/55",
+                        )}
+                      />
+                    ))}
+                  </span>
+                </button>
+              </div>
+            ) : null}
 
-            <div className="flex min-w-0 flex-col gap-3 xl:h-full xl:min-h-0 xl:min-w-[300px] xl:overflow-hidden xl:pl-0.5">
+            <div className="flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden pl-1.5 xl:min-w-[300px] xl:pl-0.5">
               {taskRelationshipsPanel}
-              <div className="min-w-0 xl:min-h-0 xl:flex-1">
+              <div className="min-h-0 min-w-0 flex-1">
                 {inspectorPanel}
               </div>
             </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -241,6 +241,21 @@ function mockDesktopLayout(width = 1200) {
   vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 }
 
+function mockNarrowLayout() {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: "(min-width: 1280px)",
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
 function hasMessageText(text, role = "") {
   const selector = role ? `[data-message-role="${role}"]` : "[data-message-role]";
   const expectedText = String(text || "").trim();
@@ -334,6 +349,34 @@ describe("App", () => {
     expect(await screen.findByRole("button", { name: "Switch language" })).toBeInTheDocument();
     expect(screen.getByText("main - Current session")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("keeps Trace & Observe docked as a narrow icon rail on narrow screens", async () => {
+    const fetchMock = vi.fn((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/runtime")) {
+        return mockJsonResponse(createSnapshot());
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    mockNarrowLayout();
+
+    const { container } = render(<App />);
+
+    expect(await screen.findByText("main - 当前会话")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "文件" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "回复摘要" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "发送" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "拖动调整聊天区与追踪区宽度" })).not.toBeInTheDocument();
+    expect(screen.queryByText("追踪与观察")).not.toBeInTheDocument();
+
+    const main = container.querySelector("main");
+    expect(main).toBeTruthy();
+    expect(main?.style.gridTemplateColumns).toMatch(/^minmax\(0, 1fr\) \d+px$/);
   });
 
   it("requests the initial runtime snapshot only once on first load", async () => {
@@ -509,6 +552,192 @@ describe("App", () => {
     });
   }, 10_000);
 
+  it("removes a queued message and skips sending it later", async () => {
+    const openClawSnapshot = createSnapshot({
+      session: {
+        ...createSnapshot().session,
+        mode: "openclaw",
+        status: "空闲",
+      },
+    });
+    let resolveFirstChat;
+    let resolveSecondChat;
+    let chatCallCount = 0;
+    const chatBodies = [];
+    const fetchMock = vi.fn((input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/runtime")) {
+        return mockJsonResponse(openClawSnapshot);
+      }
+
+      if (url === "/api/chat" && init?.method === "POST") {
+        const body = JSON.parse(init.body);
+        chatBodies.push(body);
+        chatCallCount += 1;
+
+        if (chatCallCount === 1) {
+          return new Promise((resolve) => {
+            resolveFirstChat = () =>
+              resolve(
+                mockJsonResponse({
+                  ...openClawSnapshot,
+                  outputText: `已处理：${body.messages.at(-1)?.content || ""}`,
+                  metadata: { status: "已完成 / 标准" },
+                }),
+              );
+          });
+        }
+
+        if (chatCallCount === 2) {
+          return new Promise((resolve) => {
+            resolveSecondChat = () =>
+              resolve(
+                mockJsonResponse({
+                  ...openClawSnapshot,
+                  outputText: `已处理：${body.messages.at(-1)?.content || ""}`,
+                  metadata: { status: "已完成 / 标准" },
+                }),
+              );
+          });
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<App />);
+
+    const user = userEvent.setup();
+    const composer = await screen.findByRole("textbox");
+    await user.click(screen.getByRole("button", { name: "切换为Shift + 回车发送" }));
+
+    await user.type(composer, "甲");
+    await user.click(screen.getByRole("button", { name: "发送" }));
+
+    await user.type(composer, "乙");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    await user.type(composer, "丙");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    await waitFor(() => {
+      expect(screen.getByText("待发送 2")).toBeInTheDocument();
+      expect(hasMessageText("乙", "user")).toBe(true);
+      expect(hasMessageText("丙", "user")).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: "删除第 1 条待发送消息" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("待发送 1")).toBeInTheDocument();
+      expect(hasMessageText("乙", "user")).toBe(false);
+      expect(hasMessageText("丙", "user")).toBe(true);
+    });
+
+    expect(chatBodies).toHaveLength(1);
+
+    resolveFirstChat?.();
+
+    await waitFor(() => {
+      expect(chatBodies).toHaveLength(2);
+      expect(chatBodies[1]?.messages.at(-1)?.content).toBe("丙");
+    });
+
+    resolveSecondChat?.();
+
+    await waitFor(() => {
+      expect(screen.getByText("已处理：丙")).toBeInTheDocument();
+    });
+  }, 10_000);
+
+  it("clears all queued messages and does not send them later", async () => {
+    const openClawSnapshot = createSnapshot({
+      session: {
+        ...createSnapshot().session,
+        mode: "openclaw",
+        status: "空闲",
+      },
+    });
+    let resolveFirstChat;
+    let chatCallCount = 0;
+    const chatBodies = [];
+    const fetchMock = vi.fn((input, init) => {
+      const url = String(input);
+      if (url.startsWith("/api/runtime")) {
+        return mockJsonResponse(openClawSnapshot);
+      }
+
+      if (url === "/api/chat" && init?.method === "POST") {
+        const body = JSON.parse(init.body);
+        chatBodies.push(body);
+        chatCallCount += 1;
+
+        if (chatCallCount === 1) {
+          return new Promise((resolve) => {
+            resolveFirstChat = () =>
+              resolve(
+                mockJsonResponse({
+                  ...openClawSnapshot,
+                  outputText: `已处理：${body.messages.at(-1)?.content || ""}`,
+                  metadata: { status: "已完成 / 标准" },
+                }),
+              );
+          });
+        }
+
+        return mockJsonResponse({
+          ...openClawSnapshot,
+          outputText: `已处理：${body.messages.at(-1)?.content || ""}`,
+          metadata: { status: "已完成 / 标准" },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<App />);
+
+    const user = userEvent.setup();
+    const composer = await screen.findByRole("textbox");
+    await user.click(screen.getByRole("button", { name: "切换为Shift + 回车发送" }));
+
+    await user.type(composer, "甲");
+    await user.click(screen.getByRole("button", { name: "发送" }));
+
+    await user.type(composer, "乙");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    await user.type(composer, "丙");
+    await user.keyboard("{Shift>}{Enter}{/Shift}");
+
+    await waitFor(() => {
+      expect(screen.getByText("待发送 2")).toBeInTheDocument();
+      expect(hasMessageText("乙", "user")).toBe(true);
+      expect(hasMessageText("丙", "user")).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: "清空待发送" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("待发送 2")).not.toBeInTheDocument();
+      expect(screen.queryByText("待发送 1")).not.toBeInTheDocument();
+      expect(hasMessageText("乙", "user")).toBe(false);
+      expect(hasMessageText("丙", "user")).toBe(false);
+    });
+
+    resolveFirstChat?.();
+
+    await waitFor(() => {
+      expect(screen.getByText("已处理：甲")).toBeInTheDocument();
+    });
+
+    expect(chatBodies).toHaveLength(1);
+  }, 10_000);
+
   it("suppresses dispatching a rapid duplicate while the current reply is still pending", async () => {
     const openClawSnapshot = createSnapshot({
       session: {
@@ -664,6 +893,7 @@ describe("App", () => {
     });
 
     vi.stubGlobal("fetch", fetchMock);
+    mockDesktopLayout();
 
     render(<App />);
 
@@ -1395,6 +1625,7 @@ describe("App", () => {
     expect(await screen.findByText("已发送：第一行")).toBeInTheDocument();
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/chat", expect.objectContaining({ method: "POST" }));
+      expect(textarea).toHaveValue("");
     });
   });
 

--- a/src/components/command-center/chat-panel.jsx
+++ b/src/components/command-center/chat-panel.jsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, ArrowUpToLine, Check, Copy, Paperclip, RotateCcw, Send, Square, X } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpToLine, Check, ChevronLeft, ChevronRight, Copy, Paperclip, RotateCcw, Send, Square, X } from "lucide-react";
 import { lazy, memo, Suspense, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Badge } from "@/components/ui/badge";
@@ -36,6 +36,7 @@ const artifactFocusScrollDurationMs = 320;
 const focusHighlightDurationMs = 1400;
 const messageOutlineViewportBottomGapPx = 20;
 const messageOutlineMinHeightPx = 96;
+const chatTabsScrollStepPx = 220;
 
 const assistantCompactThreshold = 72;
 const chatFontSizeClassNames = {
@@ -1436,7 +1437,7 @@ function ConnectionStatus({ composerSendMode = "enter-send", onToggleComposerSen
   );
 }
 
-function QueuedMessages({ items, textClassName }) {
+function QueuedMessages({ items, onClearAll, onRemoveItem, textClassName }) {
   const { messages } = useI18n();
 
   if (!items.length) {
@@ -1445,17 +1446,41 @@ function QueuedMessages({ items, textClassName }) {
 
   return (
     <div className="border-b border-border/70 bg-muted/20 px-3 py-2">
-      <div className="mb-1.5 flex items-center gap-2 text-[11px] text-muted-foreground">
-        <Badge variant="default" className="h-5 px-1.5 py-0 text-[10px]">
-          {messages.chat.queuedCount(items.length)}
-        </Badge>
-        <span>{messages.chat.queuedHint}</span>
+      <div className="mb-1.5 flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+        <div className="flex min-w-0 items-center gap-2">
+          <Badge variant="default" className="h-5 px-1.5 py-0 text-[10px]">
+            {messages.chat.queuedCount(items.length)}
+          </Badge>
+          <span>{messages.chat.queuedHint}</span>
+        </div>
+        {onClearAll ? (
+          <button
+            type="button"
+            className="inline-flex shrink-0 items-center rounded-sm px-2 py-1 text-[11px] font-medium text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            aria-label={messages.chat.clearQueuedMessages}
+            onClick={() => onClearAll()}
+          >
+            {messages.chat.clearQueuedMessages}
+          </button>
+        ) : null}
       </div>
       <div className="grid gap-1.5">
         {items.map((item, index) => (
-          <div key={item.id} className={cn("rounded-md border border-border/70 bg-background/80 px-2.5 py-1.5", textClassName)}>
-            <span className="mr-2 text-[10px] text-muted-foreground">#{index + 1}</span>
-            <span className="line-clamp-2 whitespace-pre-wrap">{item.content}</span>
+          <div key={item.id} className={cn("flex items-start gap-2 rounded-md border border-border/70 bg-background/80 px-2.5 py-1.5", textClassName)}>
+            <div className="min-w-0 flex-1">
+              <span className="mr-2 text-[10px] text-muted-foreground">#{index + 1}</span>
+              <span className="line-clamp-2 whitespace-pre-wrap">{item.content}</span>
+            </div>
+            {onRemoveItem ? (
+              <button
+                type="button"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition hover:bg-accent/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                aria-label={messages.chat.removeQueuedMessage(index + 1)}
+                onClick={() => onRemoveItem(item.id)}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
           </div>
         ))}
       </div>
@@ -1475,11 +1500,51 @@ export function ChatTabsStrip({
 }) {
   const { messages } = useI18n();
   const [draggingTabId, setDraggingTabId] = useState("");
+  const [tabScrollState, setTabScrollState] = useState({
+    canScrollLeft: false,
+    canScrollRight: false,
+    hasOverflow: false,
+  });
   const tabNodeMapRef = useRef(new Map());
   const previousTabRectsRef = useRef(new Map());
   const previousOrderSignatureRef = useRef("");
   const draggingTabIdRef = useRef("");
   const lastReorderIntentRef = useRef("");
+  const scrollViewportRef = useRef(null);
+  const scrollContentRef = useRef(null);
+
+  const updateTabScrollState = useCallback(() => {
+    const viewport = scrollViewportRef.current;
+    if (!viewport) {
+      setTabScrollState((current) => (
+        current.canScrollLeft || current.canScrollRight || current.hasOverflow
+          ? {
+              canScrollLeft: false,
+              canScrollRight: false,
+              hasOverflow: false,
+            }
+          : current
+      ));
+      return;
+    }
+
+    const { clientWidth, scrollLeft, scrollWidth } = viewport;
+    const hasOverflow = (scrollWidth - clientWidth) > 1;
+    const canScrollLeft = scrollLeft > 1;
+    const canScrollRight = hasOverflow && (scrollLeft + clientWidth) < (scrollWidth - 1);
+
+    setTabScrollState((current) => (
+      current.canScrollLeft === canScrollLeft
+      && current.canScrollRight === canScrollRight
+      && current.hasOverflow === hasOverflow
+        ? current
+        : {
+            canScrollLeft,
+            canScrollRight,
+            hasOverflow,
+          }
+    ));
+  }, []);
 
   useLayoutEffect(() => {
     const currentOrderSignature = items.map((item) => item.id).join("|");
@@ -1530,176 +1595,305 @@ export function ChatTabsStrip({
     previousOrderSignatureRef.current = currentOrderSignature;
   }, [draggingTabId, items]);
 
+  useLayoutEffect(() => {
+    updateTabScrollState();
+  }, [items, updateTabScrollState]);
+
+  useLayoutEffect(() => {
+    const activeItem = items.find((item) => item.active);
+    if (!activeItem) {
+      return;
+    }
+
+    const viewport = scrollViewportRef.current;
+    const activeNode = tabNodeMapRef.current.get(activeItem.id);
+    if (!viewport || !activeNode) {
+      return;
+    }
+
+    const nodeLeft = activeNode.offsetLeft;
+    const nodeRight = nodeLeft + activeNode.offsetWidth;
+    const viewLeft = viewport.scrollLeft;
+    const viewRight = viewLeft + viewport.clientWidth;
+
+    if (nodeLeft >= viewLeft && nodeRight <= viewRight) {
+      return;
+    }
+
+    activeNode.scrollIntoView?.({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [items]);
+
+  useEffect(() => {
+    const viewport = scrollViewportRef.current;
+    if (!viewport) {
+      return undefined;
+    }
+
+    updateTabScrollState();
+
+    const handleScroll = () => updateTabScrollState();
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleScroll);
+
+    const ResizeObserverCtor = window.ResizeObserver || globalThis.ResizeObserver;
+    const resizeObserver = ResizeObserverCtor ? new ResizeObserverCtor(() => updateTabScrollState()) : null;
+
+    resizeObserver?.observe(viewport);
+    if (scrollContentRef.current) {
+      resizeObserver?.observe(scrollContentRef.current);
+    }
+
+    return () => {
+      viewport.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
+      resizeObserver?.disconnect?.();
+    };
+  }, [items.length, updateTabScrollState]);
+
   if (!items.length && !leadingControl && !trailingControl) {
     return null;
   }
 
   const closable = items.length > 1;
+  const scrollTabsBy = (direction) => {
+    const viewport = scrollViewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    const delta = Math.max(chatTabsScrollStepPx, Math.round(viewport.clientWidth * 0.72)) * direction;
+    if (typeof viewport.scrollBy === "function") {
+      viewport.scrollBy({ left: delta, behavior: "smooth" });
+    } else {
+      viewport.scrollLeft += delta;
+    }
+
+    window.requestAnimationFrame(() => updateTabScrollState());
+  };
+
+  const scrollButtonClassName = "inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border bg-background text-foreground/85 transition hover:border-foreground/25 hover:bg-accent/55 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-default disabled:border-border/45 disabled:bg-muted/28 disabled:text-muted-foreground/45 disabled:opacity-100";
 
   return (
-    <div className={cn("flex items-center gap-1 overflow-x-auto overflow-y-hidden pt-1 pb-0 pr-3", className)}>
+    <div className={cn("flex min-w-0 items-center gap-1 pt-1 pb-0", className)}>
       {leadingControl ? <div className="shrink-0">{leadingControl}</div> : null}
-      {items.map((item, index) => {
-        const shortcutNumber = index < 9 ? String(index + 1) : null;
-        const isClosableActiveTab = closable && item.active;
-        const tabTitle = item.title || item.agentId;
-        const imTitleParts = splitImTabTitleForDisplay(tabTitle, item.agentId, item.sessionUser);
-
-        return (
-          <div
-            key={item.id}
-            ref={(node) => {
-              if (node) {
-                tabNodeMapRef.current.set(item.id, node);
-                return;
-              }
-              tabNodeMapRef.current.delete(item.id);
-            }}
-            draggable={items.length > 1}
-            onDragStart={(event) => {
-              draggingTabIdRef.current = item.id;
-              setDraggingTabId(item.id);
-              lastReorderIntentRef.current = "";
-              event.dataTransfer.effectAllowed = "move";
-              event.dataTransfer.setData("text/plain", item.id);
-            }}
-            onDragOver={(event) => {
-              event.preventDefault();
-              event.dataTransfer.dropEffect = "move";
-              const currentDraggingTabId = draggingTabIdRef.current || draggingTabId;
-              if (!currentDraggingTabId || currentDraggingTabId === item.id) {
-                return;
-              }
-
-              const sourceIndex = items.findIndex((entry) => entry.id === currentDraggingTabId);
-              const targetIndex = items.findIndex((entry) => entry.id === item.id);
-              if (sourceIndex === -1 || targetIndex === -1) {
-                return;
-              }
-
-              const rect = event.currentTarget.getBoundingClientRect();
-              const placeAfter = event.clientX > rect.left + rect.width / 2;
-              const currentIntentKey = `${currentDraggingTabId}:${item.id}:${placeAfter ? "after" : "before"}`;
-              if (lastReorderIntentRef.current === currentIntentKey) {
-                return;
-              }
-
-              if ((placeAfter && sourceIndex === targetIndex + 1) || (!placeAfter && sourceIndex === targetIndex - 1)) {
-                return;
-              }
-
-              lastReorderIntentRef.current = currentIntentKey;
-              onReorder?.(currentDraggingTabId, item.id, placeAfter ? "after" : "before");
-            }}
-            onDrop={(event) => {
-              event.preventDefault();
-              draggingTabIdRef.current = "";
-              setDraggingTabId("");
-              lastReorderIntentRef.current = "";
-            }}
-            onDragEnd={() => {
-              draggingTabIdRef.current = "";
-              setDraggingTabId("");
-              lastReorderIntentRef.current = "";
-            }}
-            className={cn(
-              "group inline-flex h-9 max-w-[13rem] items-center rounded-md border transition",
-              item.active
-                ? resolvedTheme === "dark"
-                  ? "border-transparent bg-[#0f3e6a] text-white shadow-sm hover:bg-[#0f3e6a]"
-                  : "border-transparent bg-[#1677eb] text-white shadow-sm hover:bg-[#0f6fe0]"
-                : "border-border/45 bg-muted/70 text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.25)] hover:border-border/70 hover:bg-muted/88",
-              draggingTabId === item.id ? "cursor-grabbing opacity-75" : "cursor-grab",
-            )}
-          >
+      {tabScrollState.hasOverflow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
             <button
               type="button"
-              draggable={false}
-              className="inline-flex h-full min-w-0 flex-1 items-center gap-2 px-2.5 text-sm outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0"
-              onMouseDown={(event) => {
-                if (event.button !== 0 || item.active) {
-                  return;
-                }
-                onActivate?.(item.id);
-              }}
-              onClick={(event) => {
-                if (event.detail !== 0) {
-                  return;
-                }
-                onActivate?.(item.id);
-              }}
+              className={scrollButtonClassName}
+              aria-label={messages.chat.scrollTabsLeft}
+              disabled={!tabScrollState.canScrollLeft}
+              onClick={() => scrollTabsBy(-1)}
             >
-              <span
-                className={cn(
-                  "h-1.5 w-1.5 shrink-0 rounded-full",
-                  item.busy
-                    ? "cc-chat-tab-busy-dot bg-emerald-500"
-                    : item.active ? "bg-white/65" : "bg-muted-foreground/35",
-                )}
-              />
-              <span className={cn("min-w-0 flex-1 truncate font-medium", item.active ? "text-white" : "text-inherit")}>
-                {imTitleParts ? (
-                  <>
-                    <span>{imTitleParts.platformLabel}</span>
-                    {" "}
-                    <span className={cn("text-[11px]", item.active ? "text-white/70" : "text-muted-foreground")}>{imTitleParts.agentName}</span>
-                  </>
-                ) : tabTitle}
-              </span>
-              {shortcutNumber && !isClosableActiveTab ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      aria-hidden="true"
-                      className={cn(
-                        "inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-[7px] border text-[11px] font-semibold leading-none tabular-nums",
-                        item.active
-                          ? "border-white/20 bg-white/12 text-white"
-                          : "border-border/60 bg-background/80 text-foreground/80",
-                      )}
-                    >
-                      {shortcutNumber}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {formatShortcutForPlatform(messages.chat.tabSwitchTooltip(shortcutNumber))}
-                  </TooltipContent>
-                </Tooltip>
-              ) : null}
+              <ChevronLeft className="h-3 w-3" />
             </button>
-          {shortcutNumber ? (
-            isClosableActiveTab ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    draggable={false}
-                    className={cn(
-                      "mr-1 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-[11px] font-semibold leading-none transition",
-                      item.active
-                        ? "text-white/90 hover:bg-white/14 hover:text-white"
-                        : "text-foreground/80 hover:bg-accent/60 hover:text-foreground",
-                    )}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onClose?.(item.id);
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{messages.chat.scrollTabsLeft}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {items.length ? (
+        <div className="min-w-0 flex-1">
+          <div
+            ref={scrollViewportRef}
+            className="cc-chat-tabs-viewport cc-tab-scrollbar-hidden min-w-0 overflow-x-auto overflow-y-hidden pt-4"
+          >
+            <div ref={scrollContentRef} className="inline-flex min-w-max items-center gap-1 px-1 pt-0 pb-1">
+              {items.map((item, index) => {
+                const shortcutNumber = index < 9 ? String(index + 1) : null;
+                const isClosableActiveTab = closable && item.active;
+                const tabTitle = item.title || item.agentId;
+                const imTitleParts = splitImTabTitleForDisplay(tabTitle, item.agentId, item.sessionUser);
+
+                return (
+                  <div
+                    key={item.id}
+                    ref={(node) => {
+                      if (node) {
+                        tabNodeMapRef.current.set(item.id, node);
+                        return;
+                      }
+                      tabNodeMapRef.current.delete(item.id);
                     }}
-                    aria-label={messages.chat.closeTabAriaLabel(tabTitle)}
+                    draggable={items.length > 1}
+                    onDragStart={(event) => {
+                      draggingTabIdRef.current = item.id;
+                      setDraggingTabId(item.id);
+                      lastReorderIntentRef.current = "";
+                      event.dataTransfer.effectAllowed = "move";
+                      event.dataTransfer.setData("text/plain", item.id);
+                    }}
+                    onDragOver={(event) => {
+                      event.preventDefault();
+                      event.dataTransfer.dropEffect = "move";
+                      const currentDraggingTabId = draggingTabIdRef.current || draggingTabId;
+                      if (!currentDraggingTabId || currentDraggingTabId === item.id) {
+                        return;
+                      }
+
+                      const sourceIndex = items.findIndex((entry) => entry.id === currentDraggingTabId);
+                      const targetIndex = items.findIndex((entry) => entry.id === item.id);
+                      if (sourceIndex === -1 || targetIndex === -1) {
+                        return;
+                      }
+
+                      const rect = event.currentTarget.getBoundingClientRect();
+                      const placeAfter = event.clientX > rect.left + rect.width / 2;
+                      const currentIntentKey = `${currentDraggingTabId}:${item.id}:${placeAfter ? "after" : "before"}`;
+                      if (lastReorderIntentRef.current === currentIntentKey) {
+                        return;
+                      }
+
+                      if ((placeAfter && sourceIndex === targetIndex + 1) || (!placeAfter && sourceIndex === targetIndex - 1)) {
+                        return;
+                      }
+
+                      lastReorderIntentRef.current = currentIntentKey;
+                      onReorder?.(currentDraggingTabId, item.id, placeAfter ? "after" : "before");
+                    }}
+                    onDrop={(event) => {
+                      event.preventDefault();
+                      draggingTabIdRef.current = "";
+                      setDraggingTabId("");
+                      lastReorderIntentRef.current = "";
+                    }}
+                    onDragEnd={() => {
+                      draggingTabIdRef.current = "";
+                      setDraggingTabId("");
+                      lastReorderIntentRef.current = "";
+                    }}
+                    className={cn(
+                      "group relative inline-flex h-9 max-w-[13rem] items-center overflow-visible rounded-md border transition",
+                      item.active
+                        ? resolvedTheme === "dark"
+                          ? "border-transparent bg-[#0f3e6a] text-white shadow-sm hover:bg-[#0f3e6a]"
+                          : "border-transparent bg-[#1677eb] text-white shadow-sm hover:bg-[#0f6fe0]"
+                        : "border-border/45 bg-muted/70 text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.25)] hover:border-border/70 hover:bg-muted/88",
+                      draggingTabId === item.id ? "cursor-grabbing opacity-75" : "cursor-grab",
+                    )}
                   >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="max-w-[16rem] px-2.5 py-2 text-left">
-                  <div className="text-xs font-medium leading-4">{messages.chat.closeTab}</div>
-                  <div className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{messages.chat.closeTabHint}</div>
-                </TooltipContent>
-              </Tooltip>
-            ) : null
-          ) : null}
+	                    {shortcutNumber ? (
+	                      <Tooltip>
+	                        <TooltipTrigger asChild>
+	                          <button
+	                            type="button"
+	                            draggable={false}
+	                            className={cn(
+	                              "absolute left-3 top-[-0.72rem] z-10 inline-flex min-w-3 items-center justify-center px-0.5 text-[11px] font-semibold leading-none tabular-nums",
+	                              item.active ? "text-primary" : "text-muted-foreground",
+	                            )}
+	                            onMouseDown={(event) => {
+	                              event.stopPropagation();
+	                              if (event.button !== 0 || item.active) {
+	                                return;
+	                              }
+	                              onActivate?.(item.id);
+	                            }}
+	                            onClick={(event) => {
+	                              event.stopPropagation();
+	                              onActivate?.(item.id);
+	                            }}
+	                          >
+	                            {shortcutNumber}
+	                          </button>
+	                        </TooltipTrigger>
+	                        <TooltipContent side="bottom">
+	                          {formatShortcutForPlatform(messages.chat.tabSwitchTooltip(shortcutNumber))}
+	                        </TooltipContent>
+	                      </Tooltip>
+	                    ) : null}
+	                    <button
+	                      type="button"
+	                      draggable={false}
+	                      className="relative inline-flex h-full min-w-0 flex-1 items-center gap-2 px-2.5 text-sm outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0"
+	                      onMouseDown={(event) => {
+                        if (event.button !== 0 || item.active) {
+                          return;
+                        }
+                        onActivate?.(item.id);
+                      }}
+                      onClick={(event) => {
+                        if (event.detail !== 0) {
+                          return;
+                        }
+                        onActivate?.(item.id);
+                      }}
+                    >
+                      <span
+                        className={cn(
+                          "h-1.5 w-1.5 shrink-0 rounded-full",
+                          item.busy
+                            ? "cc-chat-tab-busy-dot bg-emerald-500"
+                            : item.active ? "bg-white/65" : "bg-muted-foreground/35",
+                        )}
+                      />
+                      <span className={cn("min-w-0 flex-1 truncate font-medium", item.active ? "text-white" : "text-inherit")}>
+                        {imTitleParts ? (
+                          <>
+                            <span>{imTitleParts.platformLabel}</span>
+                            {" "}
+                            <span className={cn("text-[11px]", item.active ? "text-white/70" : "text-muted-foreground")}>{imTitleParts.agentName}</span>
+                          </>
+                        ) : tabTitle}
+                      </span>
+	                    </button>
+                    {shortcutNumber ? (
+                      isClosableActiveTab ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              draggable={false}
+                              className={cn(
+                                "mr-1 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-[11px] font-semibold leading-none transition",
+                                item.active
+                                  ? "text-white/90 hover:bg-white/14 hover:text-white"
+                                  : "text-foreground/80 hover:bg-accent/60 hover:text-foreground",
+                              )}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onClose?.(item.id);
+                              }}
+                              aria-label={messages.chat.closeTabAriaLabel(tabTitle)}
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom" className="max-w-[16rem] px-2.5 py-2 text-left">
+                            <div className="text-xs font-medium leading-4">{messages.chat.closeTab}</div>
+                            <div className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{messages.chat.closeTabHint}</div>
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : null
+                    ) : null}
+                  </div>
+                );
+              })}
+              {trailingControl ? <div className="shrink-0 pl-1">{trailingControl}</div> : null}
+            </div>
           </div>
-        );
-      })}
-      {trailingControl ? <div className="shrink-0">{trailingControl}</div> : null}
+        </div>
+      ) : null}
+      {tabScrollState.hasOverflow ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className={scrollButtonClassName}
+              aria-label={messages.chat.scrollTabsRight}
+              disabled={!tabScrollState.canScrollRight}
+              onClick={() => scrollTabsBy(1)}
+            >
+              <ChevronRight className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{messages.chat.scrollTabsRight}</TooltipContent>
+        </Tooltip>
+      ) : null}
     </div>
   );
 }
@@ -1727,10 +1921,13 @@ export function ChatPanel({
   onRemoveAttachment,
   onPromptChange,
   onPromptKeyDown,
+  onClearQueuedMessages,
+  onRemoveQueuedMessage,
   onReset,
   onSend,
   onStop,
   prompt,
+  promptSyncVersion = 0,
   promptRef,
   queuedMessages,
   resolvedTheme,
@@ -1796,8 +1993,12 @@ export function ChatPanel({
     }
     return i18n.chat.promptPlaceholder;
   }, [currentAgentName, i18n.chat]);
+  const promptPlaceholderVisual = useMemo(
+    () => String(promptPlaceholder || "").replace(/^\s*💡\s*/, ""),
+    [promptPlaceholder],
+  );
   const promptPlaceholderSegments = useMemo(() => {
-    const placeholderText = String(promptPlaceholder || "");
+    const placeholderText = String(promptPlaceholderVisual || "");
     const agentName = String(currentAgentName || "");
     if (!agentName) {
       return { before: placeholderText, agent: "", after: "" };
@@ -1811,7 +2012,7 @@ export function ChatPanel({
       agent: agentName,
       after: placeholderText.slice(agentIndex + agentName.length),
     };
-  }, [currentAgentName, promptPlaceholder]);
+  }, [currentAgentName, promptPlaceholderVisual]);
   const latestMessageCardKey = useMemo(() => {
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage) {
@@ -1932,7 +2133,7 @@ export function ChatPanel({
 
   useEffect(() => {
     setComposerPrompt((current) => (current === prompt ? current : prompt));
-  }, [prompt]);
+  }, [prompt, promptSyncVersion]);
 
   useLayoutEffect(() => {
     const textarea = composerTextareaRef.current;
@@ -2921,7 +3122,12 @@ export function ChatPanel({
             {sessionOverview ? <div className="mt-2">{sessionOverview}</div> : null}
           </div>
           <CardContent className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] p-0">
-            <QueuedMessages items={queuedMessages || []} textClassName={fontSizeStyles.queued} />
+            <QueuedMessages
+              items={queuedMessages || []}
+              onClearAll={onClearQueuedMessages}
+              onRemoveItem={onRemoveQueuedMessage}
+              textClassName={fontSizeStyles.queued}
+            />
             <div className="relative min-h-0">
               <ScrollArea
                 className="h-full"
@@ -3051,15 +3257,17 @@ export function ChatPanel({
                 {openClawConnected && !composerPrompt ? (
                   <div
                     aria-hidden="true"
-                    className="pointer-events-none absolute inset-x-0 top-0 px-3 py-2 text-sm text-muted-foreground"
+                    data-testid="composer-placeholder-overlay"
+                    className="pointer-events-none absolute inset-x-0 top-0 px-3 py-2 text-sm text-muted-foreground/75"
                   >
                     <span>{promptPlaceholderSegments.before}</span>
                     {promptPlaceholderSegments.agent ? (
-                      <span className="font-semibold text-foreground/90">
+                      <span className="font-medium text-muted-foreground/75">
                         {promptPlaceholderSegments.agent}
                       </span>
                     ) : null}
                     <span>{promptPlaceholderSegments.after}</span>
+                    <span className="ml-1 text-inherit">💡</span>
                   </div>
                 ) : null}
                 <Textarea

--- a/src/components/command-center/chat-panel.test.jsx
+++ b/src/components/command-center/chat-panel.test.jsx
@@ -75,7 +75,7 @@ describe("ChatPanel", () => {
     ).toBe(false);
   });
 
-  it("keeps the tabs strip from showing a vertical scrollbar when the leading control animates", () => {
+  it("keeps the scrollable tab viewport clipped when the leading control animates", () => {
     const { container } = render(
       <TooltipProvider>
         <ChatTabsStrip
@@ -85,7 +85,83 @@ describe("ChatPanel", () => {
       </TooltipProvider>,
     );
 
-    expect(container.firstChild).toHaveClass("overflow-x-auto", "overflow-y-hidden");
+    expect(container.firstChild).toHaveClass("min-w-0");
+    expect(container.firstChild).not.toHaveClass("overflow-x-auto");
+  });
+
+  it("renders scroll buttons for overflowing tabs and scrolls the tab rail", async () => {
+    const { container } = render(
+      <TooltipProvider>
+        <ChatTabsStrip
+          items={[
+            { id: "agent:main", agentId: "main", active: true, busy: false, title: "main" },
+            { id: "agent:writer", agentId: "writer", active: false, busy: false, title: "writer" },
+            { id: "agent:expert", agentId: "expert", active: false, busy: false, title: "expert" },
+            { id: "agent:transformer", agentId: "transformer", active: false, busy: false, title: "transformer" },
+          ]}
+        />
+      </TooltipProvider>,
+    );
+
+    const viewport = container.querySelector(".cc-chat-tabs-viewport");
+    expect(viewport).toBeTruthy();
+
+    let scrollLeftValue = 0;
+    Object.defineProperty(viewport, "clientWidth", {
+      configurable: true,
+      get: () => 180,
+    });
+    Object.defineProperty(viewport, "scrollWidth", {
+      configurable: true,
+      get: () => 520,
+    });
+    Object.defineProperty(viewport, "scrollLeft", {
+      configurable: true,
+      get: () => scrollLeftValue,
+      set: (value) => {
+        scrollLeftValue = value;
+      },
+    });
+    viewport.scrollBy = vi.fn(({ left }) => {
+      scrollLeftValue += left;
+      fireEvent.scroll(viewport);
+    });
+
+    fireEvent(window, new Event("resize"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "向左滚动会话标签" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "向右滚动会话标签" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "向左滚动会话标签" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "向右滚动会话标签" })).not.toBeDisabled();
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "向右滚动会话标签" }));
+
+    expect(viewport.scrollBy).toHaveBeenCalledTimes(1);
+    expect(scrollLeftValue).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "向左滚动会话标签" })).not.toBeDisabled();
+  });
+
+  it("keeps the trailing control inside the tab rail after the session tabs", () => {
+    const { container } = render(
+      <TooltipProvider>
+        <ChatTabsStrip
+          items={[
+            { id: "agent:main", agentId: "main", active: true, busy: false, title: "main" },
+            { id: "agent:writer", agentId: "writer", active: false, busy: false, title: "writer" },
+          ]}
+          trailingControl={<button type="button">Open session</button>}
+        />
+      </TooltipProvider>,
+    );
+
+    const viewport = container.querySelector(".cc-chat-tabs-viewport");
+    expect(viewport).toContainElement(screen.getByRole("button", { name: "Open session" }));
+
+    const trackLabels = Array.from(viewport.textContent.matchAll(/main|writer|Open session/g)).map(([value]) => value);
+    expect(trackLabels).toEqual(["main", "writer", "Open session"]);
   });
 
   it("renders empty state and forwards reset/send actions", async () => {
@@ -127,7 +203,7 @@ describe("ChatPanel", () => {
     expect(onSend).toHaveBeenCalledTimes(1);
   });
 
-  it("renders the agent name in the composer placeholder with semibold weight", () => {
+  it("renders the composer placeholder with the agent name emphasized but not darker than the rest", () => {
     render(
       <TooltipProvider>
         <ChatPanel
@@ -149,7 +225,9 @@ describe("ChatPanel", () => {
     );
 
     expect(screen.getByPlaceholderText("💡 想要和 writer 一起做点什么？")).toBeInTheDocument();
-    expect(screen.getByText("writer", { selector: "span" })).toHaveClass("font-semibold");
+    const overlay = screen.getByTestId("composer-placeholder-overlay");
+    expect(overlay).toHaveTextContent("想要和 writer 一起做点什么？💡");
+    expect(screen.getByText("writer", { selector: "span" })).toHaveClass("font-medium", "text-muted-foreground/75");
   });
 
   it("cancels resetting the conversation when the custom dialog is dismissed", async () => {
@@ -806,8 +884,23 @@ describe("ChatPanel", () => {
     );
 
     expect(screen.getAllByText("1").length).toBeGreaterThan(0);
-    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.getAllByText("2").length).toBeGreaterThan(0);
     expect(screen.getAllByText("3").length).toBeGreaterThan(0);
+  });
+
+  it("pins inactive tab shortcut numbers to the top-left corner badge position", () => {
+    render(
+      <TooltipProvider>
+        <ChatTabsStrip
+          items={[
+            { id: "agent:main", agentId: "main", active: true, busy: false, title: "main" },
+            { id: "agent:writer", agentId: "writer", active: false, busy: false, title: "writer" },
+          ]}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("2")).toHaveClass("absolute", "left-3", "top-[-0.72rem]", "text-[11px]");
   });
 
   it("adds the breathing highlight treatment to busy tab dots only", () => {

--- a/src/components/command-center/inspector-panel.jsx
+++ b/src/components/command-center/inspector-panel.jsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useFilePreview } from "@/components/command-center/use-file-preview";
 import { getLocalizedStatusLabel, getRelationshipStatusBadgeProps, localizeStatusSummary, normalizeStatusKey } from "@/features/session/status-display";
 import { Prism, usePrismLanguage } from "@/lib/prism-languages";
@@ -1735,6 +1736,7 @@ function EnvironmentTab({ section, messages }) {
 export function InspectorPanel({
   activeTab,
   artifacts,
+  compact = false,
   currentAgentId = "",
   currentSessionUser = "",
   currentWorkspaceRoot = "",
@@ -1750,6 +1752,7 @@ export function InspectorPanel({
   const tabsListRef = useRef(null);
   const [showTabLabels, setShowTabLabels] = useState(true);
   const [tooltipTabKey, setTooltipTabKey] = useState("");
+  const [compactSheetOpen, setCompactSheetOpen] = useState(false);
   const workspaceFiles = peeks?.workspace?.entries || [];
   const workspaceCount = Number(peeks?.workspace?.totalCount);
   const workspaceLoaded = Array.isArray(peeks?.workspace?.entries);
@@ -1806,6 +1809,185 @@ export function InspectorPanel({
       setTooltipTabKey("");
     }
   }, [showTabLabels, tooltipTabKey]);
+
+  useEffect(() => {
+    if (!compact && compactSheetOpen) {
+      setCompactSheetOpen(false);
+    }
+  }, [compact, compactSheetOpen]);
+
+  useEffect(() => {
+    if ((filePreview || imagePreview) && compactSheetOpen) {
+      setCompactSheetOpen(false);
+    }
+  }, [compactSheetOpen, filePreview, imagePreview]);
+
+  useEffect(() => {
+    if (!compactSheetOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setCompactSheetOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [compactSheetOpen]);
+
+  const filesTabContent = (
+    <FilesTab
+      currentAgentId={currentAgentId}
+      currentSessionUser={currentSessionUser}
+      items={files}
+      messages={messages}
+      onOpenEdit={(item) => handleOpenPreview(item, { startInEditMode: true })}
+      onOpenPreview={handleOpenPreview}
+      currentWorkspaceRoot={currentWorkspaceRoot}
+      workspaceCount={workspaceCount}
+      workspaceItems={workspaceFiles}
+      workspaceLoaded={workspaceLoaded}
+    />
+  );
+  const artifactsTabContent = (
+    <DataList
+      items={artifacts}
+      hint={messages.inspector.artifactsHint}
+      empty={messages.inspector.empty.artifacts}
+      getItemActionLabel={(item) => `${messages.inspector.artifactJumpTo} ${localizeArtifactTitle(item.title || messages.inspector.tabs.artifacts, messages)}`}
+      onSelect={onSelectArtifact}
+      render={(item) => (
+        <>
+          <div className="text-sm font-medium">{localizeArtifactTitle(item.title, messages)}</div>
+          <div className="text-xs text-muted-foreground">{stripMarkdownForDisplay(item.detail)}</div>
+        </>
+      )}
+    />
+  );
+  const timelineTabContent = (
+    <TimelineTab items={taskTimeline} messages={messages} onOpenPreview={handleOpenPreview} resolvedTheme={resolvedTheme} currentWorkspaceRoot={currentWorkspaceRoot} />
+  );
+  const environmentTabContent = <EnvironmentTab section={peeks?.environment} messages={messages} />;
+  const tabContentByKey = {
+    files: filesTabContent,
+    artifacts: artifactsTabContent,
+    timeline: timelineTabContent,
+    environment: environmentTabContent,
+  };
+  const activeCompactTab = tabDefinitions.find((tab) => tab.key === resolvedActiveTab) || tabDefinitions[0];
+
+  if (compact) {
+    return (
+      <>
+        <div className="flex h-full min-h-0 min-w-0 flex-col items-center gap-2 rounded-[18px] border border-border/70 bg-card/80 px-1.5 py-2 backdrop-blur">
+          {tabDefinitions.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = compactSheetOpen && resolvedActiveTab === tab.key;
+            return (
+              <Tooltip key={tab.key}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={tab.label}
+                    onClick={() => {
+                      setActiveTab(tab.key);
+                      setCompactSheetOpen(true);
+                    }}
+                    className={cn(
+                      "relative inline-flex h-10 w-10 items-center justify-center rounded-lg border transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                      isActive
+                        ? resolvedTheme === "dark"
+                          ? "border-[#0f3e6a] bg-[#0f3e6a] text-white"
+                          : "border-[#1677eb] bg-[#1677eb] text-white"
+                        : "border-transparent bg-background/75 text-muted-foreground hover:border-border/70 hover:bg-muted/60 hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="h-4.5 w-4.5 shrink-0 stroke-[1.9]" />
+                    {tab.count ? (
+                      <span
+                        className={cn(
+                          "absolute -right-1 -top-1 min-w-[1.15rem] rounded-full px-1 py-[1px] text-center text-[10px] font-semibold leading-none",
+                          isActive ? "bg-white/22 text-white" : "bg-muted text-foreground",
+                        )}
+                      >
+                        {tab.count}
+                      </span>
+                    ) : null}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="left">{tab.label}</TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+        {compactSheetOpen ? (
+          <>
+            <button
+              type="button"
+              aria-label={messages.inspector.compact.closeSheet}
+              className="fixed inset-0 z-40 bg-background/42 backdrop-blur-[1px]"
+              onClick={() => setCompactSheetOpen(false)}
+            />
+            <div className="fixed inset-y-0 right-0 z-[41] w-[min(28rem,calc(100vw-5.5rem))] min-w-[18rem] max-w-[30rem] pl-3">
+              <Card
+                role="dialog"
+                aria-modal="true"
+                aria-label={`${messages.inspector.title} - ${activeCompactTab.label}`}
+                className="flex h-full min-h-0 flex-col overflow-hidden rounded-none rounded-l-[1.5rem] border-y-0 border-r-0 shadow-[0_18px_55px_rgba(15,23,42,0.18)]"
+              >
+                <CardHeader className="flex min-h-12 flex-row items-start justify-between gap-3 border-b border-border/70 bg-card/92 px-4 py-3 text-left backdrop-blur">
+                  <div className="min-w-0 flex-1">
+                    <CardTitle className="truncate text-sm leading-[1.15]">{activeCompactTab.label}</CardTitle>
+                    <CardDescription className="mt-1 line-clamp-2 text-[11px] leading-4">
+                      {messages.inspector.subtitle}
+                    </CardDescription>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={messages.inspector.compact.closeSheet}
+                    className="h-8 w-8 shrink-0 rounded-md text-muted-foreground hover:text-foreground"
+                    onClick={() => setCompactSheetOpen(false)}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </CardHeader>
+                <CardContent className="flex min-h-0 min-w-0 flex-1 flex-col p-4">
+                  {tabContentByKey[resolvedActiveTab]}
+                </CardContent>
+              </Card>
+            </div>
+          </>
+        ) : null}
+        {filePreview ? (
+          <Suspense fallback={null}>
+            <LazyFilePreviewOverlay
+              currentAgentId={currentAgentId}
+              currentSessionUser={currentSessionUser}
+              currentWorkspaceRoot={currentWorkspaceRoot}
+              files={previewFiles}
+              preview={filePreview}
+              resolvedTheme={resolvedTheme}
+              sessionFiles={files}
+              onClose={closeFilePreview}
+              onOpenFilePreview={handleOpenPreview}
+              workspaceCount={workspaceCount}
+              workspaceFiles={workspaceFiles}
+              workspaceLoaded={workspaceLoaded}
+            />
+          </Suspense>
+        ) : null}
+        {imagePreview ? (
+          <Suspense fallback={null}>
+            <LazyImagePreviewOverlay image={imagePreview} onClose={closeImagePreview} />
+          </Suspense>
+        ) : null}
+      </>
+    );
+  }
 
   return (
     <>
@@ -1884,42 +2066,19 @@ export function InspectorPanel({
             </TabsList>
 
             <TabsContent value="files" className="mt-1 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col">
-              <FilesTab
-                currentAgentId={currentAgentId}
-                currentSessionUser={currentSessionUser}
-                items={files}
-                messages={messages}
-                onOpenEdit={(item) => handleOpenPreview(item, { startInEditMode: true })}
-                onOpenPreview={handleOpenPreview}
-                currentWorkspaceRoot={currentWorkspaceRoot}
-                workspaceCount={workspaceCount}
-                workspaceItems={workspaceFiles}
-                workspaceLoaded={workspaceLoaded}
-              />
+              {filesTabContent}
             </TabsContent>
 
             <TabsContent value="artifacts" className="mt-1 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col">
-              <DataList
-                items={artifacts}
-                hint={messages.inspector.artifactsHint}
-                empty={messages.inspector.empty.artifacts}
-                getItemActionLabel={(item) => `${messages.inspector.artifactJumpTo} ${localizeArtifactTitle(item.title || messages.inspector.tabs.artifacts, messages)}`}
-                onSelect={onSelectArtifact}
-                render={(item) => (
-                  <>
-                    <div className="text-sm font-medium">{localizeArtifactTitle(item.title, messages)}</div>
-                    <div className="text-xs text-muted-foreground">{stripMarkdownForDisplay(item.detail)}</div>
-                  </>
-                )}
-              />
+              {artifactsTabContent}
             </TabsContent>
 
             <TabsContent value="timeline" className="mt-1 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col">
-              <TimelineTab items={taskTimeline} messages={messages} onOpenPreview={handleOpenPreview} resolvedTheme={resolvedTheme} currentWorkspaceRoot={currentWorkspaceRoot} />
+              {timelineTabContent}
             </TabsContent>
 
             <TabsContent value="environment" className="mt-1 min-h-0 flex-1 overflow-hidden data-[state=active]:flex data-[state=active]:flex-col">
-              <EnvironmentTab section={peeks?.environment} messages={messages} />
+              {environmentTabContent}
             </TabsContent>
           </Tabs>
         </CardContent>

--- a/src/components/command-center/inspector-panel.test.jsx
+++ b/src/components/command-center/inspector-panel.test.jsx
@@ -341,6 +341,125 @@ describe("InspectorPanel", () => {
     expect(screen.getByTestId("inspector-tab-tooltip-environment")).toHaveTextContent("环境");
   });
 
+  it("renders a compact vertical icon rail with tooltips", async () => {
+    const [activeTab, setActiveTab] = ["timeline", () => {}];
+
+    renderWithTooltip(
+      <InspectorPanel
+        activeTab={activeTab}
+        compact
+        agents={[]}
+        artifacts={[]}
+        files={[{ path: "src/App.jsx", kind: "文件" }]}
+        peeks={{ workspace: null, terminal: null, browser: null, environment: null }}
+        renderPeek={(_, fallback) => fallback}
+        setActiveTab={setActiveTab}
+        taskTimeline={[]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "文件" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "回复摘要" })).toBeInTheDocument();
+    expect(screen.queryByText("追踪与观察")).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.hover(screen.getByRole("button", { name: "环境" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("环境");
+  });
+
+  it("opens a right-side sheet for the selected compact inspector tab", async () => {
+    function CompactHarness() {
+      const [activeTab, setActiveTab] = useState("timeline");
+
+      return (
+        <InspectorPanel
+          activeTab={activeTab}
+          compact
+          artifacts={[]}
+          files={[{ path: "src/App.jsx", kind: "文件" }]}
+          peeks={{
+            environment: {
+              summary: "这里列出 Gateway 与会话环境信息。",
+              items: [{ label: "gateway.baseUrl", value: "http://127.0.0.1:18789" }],
+            },
+            workspace: null,
+            terminal: null,
+            browser: null,
+          }}
+          renderPeek={(_, fallback) => fallback}
+          setActiveTab={setActiveTab}
+          taskTimeline={[]}
+        />
+      );
+    }
+
+    renderWithTooltip(<CompactHarness />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "环境" }));
+
+    const sheet = await screen.findByRole("dialog", { name: "追踪与观察 - 环境" });
+    expect(within(sheet).getByText("环境")).toBeInTheDocument();
+    expect(within(sheet).getByText("gateway.baseUrl")).toBeInTheDocument();
+    expect(within(sheet).getByText("http://127.0.0.1:18789")).toBeInTheDocument();
+
+    await user.click(within(sheet).getByRole("button", { name: "关闭追踪面板" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "追踪与观察 - 环境" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes the compact sheet before showing a file preview overlay", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          kind: "markdown",
+          path: "/Users/marila/projects/lalaclaw/AGENTS.md",
+          name: "AGENTS.md",
+          content: "# AGENTS\n\nhello compact preview",
+        }),
+      })),
+    );
+
+    function CompactPreviewHarness() {
+      const [activeTab, setActiveTab] = useState("files");
+
+      return (
+        <InspectorPanel
+          activeTab={activeTab}
+          compact
+          artifacts={[]}
+          currentWorkspaceRoot="/Users/marila/projects/lalaclaw"
+          files={[
+            { path: "/Users/marila/projects/lalaclaw/AGENTS.md", fullPath: "/Users/marila/projects/lalaclaw/AGENTS.md", kind: "文件", primaryAction: "viewed" },
+          ]}
+          peeks={{ workspace: null, terminal: null, browser: null, environment: null }}
+          renderPeek={(_, fallback) => fallback}
+          setActiveTab={setActiveTab}
+          taskTimeline={[]}
+        />
+      );
+    }
+
+    renderWithTooltip(<CompactPreviewHarness />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "文件" }));
+    expect(await screen.findByRole("dialog", { name: "追踪与观察 - 文件" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "AGENTS.md" }));
+
+    expect(await screen.findByText("hello compact preview")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "追踪与观察 - 文件" })).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps the active tab highlighted in icon-only mode after click", async () => {
     mockResizeObserver(360);
 

--- a/src/components/command-center/session-overview.jsx
+++ b/src/components/command-center/session-overview.jsx
@@ -1906,11 +1906,11 @@ export function SessionOverview({
               disabled={!openClawConnected}
               aria-label={messages.sessionOverview.menus.switchAgentTrigger || messages.sessionOverview.menus.switchAgent}
               className={cn(
-                "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-[background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-55",
-                "border-border/45 bg-background shadow-[inset_0_1px_0_rgba(255,255,255,0.25)] hover:border-border/70 hover:bg-muted/30 focus-visible:border-border/70 focus-visible:bg-muted/30 focus-visible:ring-border/50",
+                "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-[background-color,border-color,color] focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-55",
+                "border-border/80 bg-muted/20 text-foreground hover:border-border hover:bg-muted/45 focus-visible:border-border focus-visible:bg-muted/45 focus-visible:ring-border/50",
               )}
             >
-              <Plus className="h-4 w-4 text-foreground" aria-hidden="true" />
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </button>
           </SelectionMenu>
         </div>

--- a/src/features/app/controllers/use-command-center.js
+++ b/src/features/app/controllers/use-command-center.js
@@ -397,6 +397,7 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
   const [model, setModel] = useState(initialActiveMeta.model || "");
   const [fastMode, setFastMode] = useState(Boolean(initialActiveMeta.fastMode));
   const [prompt, setPrompt] = useState(storedPromptDrafts[initialConversationKey] || "");
+  const [promptSyncVersion, setPromptSyncVersion] = useState(0);
   const promptRef = useRef(null);
   const promptValueRef = useRef(storedPromptDrafts[initialConversationKey] || "");
   const promptDraftFlushTimeoutRef = useRef(0);
@@ -736,11 +737,13 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
 
   const {
     activeQueuedMessages,
+    clearQueuedEntries,
     composerAttachments,
     enqueueOrRunEntry,
     handleAddAttachments,
     handleRemoveAttachment,
     handleStop,
+    removeQueuedEntry,
     setComposerAttachments,
     setQueuedMessages,
   } = useChatController({
@@ -857,6 +860,9 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
       promptValueRef.current = normalized;
       if (syncVisible) {
         setPrompt((current) => (current === normalized ? current : normalized));
+        if (prompt === normalized) {
+          setPromptSyncVersion((current) => current + 1);
+        }
       }
     }
 
@@ -885,7 +891,7 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
     }
 
     return normalized;
-  }, [activeConversationKey, flushPromptDraftsState, schedulePromptDraftsStateFlush]);
+  }, [activeConversationKey, flushPromptDraftsState, prompt, schedulePromptDraftsStateFlush]);
 
   const persistConversationScrollTop = useCallback((conversationKey, scrollTop) => {
     const normalizedKey = String(conversationKey || "").trim();
@@ -1614,6 +1620,8 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
   }, [activeConversationKey, persistConversationScrollTop]);
 
   const handleSend = sendCurrentPrompt;
+  const handleRemoveQueuedMessage = removeQueuedEntry;
+  const handleClearQueuedMessages = clearQueuedEntries;
 
   const handleReset = async () => {
     const currentSessionUser = String(sessionStateRef.current.sessionUser || "").trim();
@@ -2231,7 +2239,9 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
     handleModelChange,
     handlePromptChange,
     handlePromptKeyDown,
+    handleClearQueuedMessages,
     handleRemoveAttachment,
+    handleRemoveQueuedMessage,
     handleReset,
     handleSend,
     handleSelectSearchedSession,
@@ -2245,6 +2255,7 @@ export function useCommandCenter({ userLabel = "marila" } = {}) {
     inspectorPanelWidth,
     peeks,
     prompt,
+    promptSyncVersion,
     promptRef,
     renderPeek,
     resolvedTheme,

--- a/src/features/chat/controllers/use-chat-controller.js
+++ b/src/features/chat/controllers/use-chat-controller.js
@@ -130,6 +130,27 @@ function ensureOptimisticTurnMessages(
   return next;
 }
 
+function removeOptimisticTurnMessages(current = [], entry = {}) {
+  const next = Array.isArray(current) ? [...current] : [];
+  const userMessageId = String(entry.userMessageId || "").trim();
+  const assistantMessageId = String(entry.assistantMessageId || "").trim();
+  const pendingTimestamp = Number(entry.pendingTimestamp || 0);
+
+  return next.filter((message) => {
+    const messageId = String(message?.id || "").trim();
+    if (userMessageId && messageId === userMessageId) {
+      return false;
+    }
+    if (assistantMessageId && messageId === assistantMessageId) {
+      return false;
+    }
+    if (pendingTimestamp && Number(message?.timestamp || 0) === pendingTimestamp && message?.pending) {
+      return false;
+    }
+    return true;
+  });
+}
+
 function replacePendingAssistantMessage(current = [], pendingTimestamp, content, tokenBadge = "", streaming = false, messageId = "") {
   const next = Array.isArray(current) ? [...current] : [];
   const assistantMessage = {
@@ -797,6 +818,81 @@ export function useChatController({
     setComposerAttachments((current) => current.filter((attachment) => attachment.id !== attachmentId));
   };
 
+  const clearLastAcceptedEntryForTab = useCallback((tabId, entry = null) => {
+    const normalizedTabId = String(tabId || resolvedActiveTabId || "").trim();
+    if (!normalizedTabId) {
+      return;
+    }
+
+    const lastAcceptedEntry = lastAcceptedEntryByTabRef.current[normalizedTabId];
+    if (!lastAcceptedEntry) {
+      return;
+    }
+
+    if (entry) {
+      const entryFingerprint = createEntryFingerprint(entry);
+      const entryTimestamp = Number(entry.timestamp || 0);
+      if (lastAcceptedEntry.fingerprint !== entryFingerprint || lastAcceptedEntry.timestamp !== entryTimestamp) {
+        return;
+      }
+    }
+
+    const nextAcceptedEntries = { ...lastAcceptedEntryByTabRef.current };
+    delete nextAcceptedEntries[normalizedTabId];
+    lastAcceptedEntryByTabRef.current = nextAcceptedEntries;
+  }, [resolvedActiveTabId]);
+
+  const removeQueuedEntry = useCallback((entryId) => {
+    const normalizedEntryId = String(entryId || "").trim();
+    if (!normalizedEntryId) {
+      return false;
+    }
+
+    const queuedEntry = queuedMessages.find((item) => String(item?.id || "").trim() === normalizedEntryId);
+    if (!queuedEntry) {
+      return false;
+    }
+
+    const targetTabId = queuedEntry.tabId || resolvedActiveTabId;
+    const nextMessages = removeOptimisticTurnMessages(getMessagesForTab(targetTabId), queuedEntry);
+    setQueuedMessages((current) => current.filter((item) => String(item?.id || "").trim() !== normalizedEntryId));
+    setMessagesForTab(targetTabId, nextMessages);
+    clearLastAcceptedEntryForTab(targetTabId, queuedEntry);
+    persistOptimisticChatState({
+      tabId: targetTabId,
+      nextMessages,
+    });
+    return true;
+  }, [clearLastAcceptedEntryForTab, getMessagesForTab, persistOptimisticChatState, queuedMessages, resolvedActiveTabId, setMessagesForTab]);
+
+  const clearQueuedEntries = useCallback((tabId = resolvedActiveTabId) => {
+    const targetTabId = String(tabId || resolvedActiveTabId || "").trim();
+    if (!targetTabId) {
+      return 0;
+    }
+
+    const entriesToClear = queuedMessages.filter((item) => String(item?.tabId || resolvedActiveTabId || "").trim() === targetTabId);
+    if (!entriesToClear.length) {
+      return 0;
+    }
+
+    const nextMessages = entriesToClear.reduce(
+      (current, entry) => removeOptimisticTurnMessages(current, entry),
+      getMessagesForTab(targetTabId),
+    );
+
+    setQueuedMessages((current) =>
+      current.filter((item) => String(item?.tabId || resolvedActiveTabId || "").trim() !== targetTabId),
+    );
+    setMessagesForTab(targetTabId, nextMessages);
+    clearLastAcceptedEntryForTab(targetTabId);
+    persistOptimisticChatState({
+      tabId: targetTabId,
+      nextMessages,
+    });
+    return entriesToClear.length;
+  }, [clearLastAcceptedEntryForTab, getMessagesForTab, persistOptimisticChatState, queuedMessages, resolvedActiveTabId, setMessagesForTab]);
+
   const enqueueOrRunEntry = async (entry) => {
     const targetTabId = entry.tabId || resolvedActiveTabId;
     const resolvedEntry = withOptimisticTurnIds({ ...entry, tabId: targetTabId });
@@ -856,9 +952,11 @@ export function useChatController({
     activeQueuedMessages,
     composerAttachments,
     enqueueOrRunEntry,
+    clearQueuedEntries,
     handleAddAttachments,
     handleRemoveAttachment,
     handleStop,
+    removeQueuedEntry,
     setComposerAttachments,
     setQueuedMessages,
   };

--- a/src/index.css
+++ b/src/index.css
@@ -296,6 +296,15 @@
     background-color: var(--scrollbar-thumb-hover);
   }
 
+  .cc-tab-scrollbar-hidden {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .cc-tab-scrollbar-hidden::-webkit-scrollbar {
+    display: none;
+  }
+
   html[data-theme="dark"] .cc-inline-code,
   html[data-theme="dark"] .cc-inline-code[class] {
     border: 0 !important;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -263,6 +263,8 @@ const en = {
     uploadAttachment: "Upload images or files",
     queuedCount: (count) => `Queued ${count}`,
     queuedHint: "These messages will be sent in order after the current reply finishes",
+    clearQueuedMessages: "Clear queued",
+    removeQueuedMessage: (index) => `Remove queued message ${index}`,
     outline: "Outline",
     copyMessage: "Copy message text",
     copiedMessage: "Message copied",
@@ -287,6 +289,8 @@ const en = {
     jumpToPreviousUserMessage: "Jump to previous user message",
     tabShortcutHint: (number) => `Cmd + ${number}`,
     tabSwitchTooltip: (number) => `Cmd + ${number} to switch to this session`,
+    scrollTabsLeft: "Scroll session tabs left",
+    scrollTabsRight: "Scroll session tabs right",
     closeTab: "Close session",
     closeTabHint: "This does not clear the conversation. You can open it again later.",
     closeTabAriaLabel: (agent) => `Close session ${agent}`,
@@ -294,6 +298,9 @@ const en = {
   inspector: {
     title: "Trace & Observe",
     subtitle: "Files, summaries, run logs, and environment for the current session",
+    compact: {
+      closeSheet: "Close trace panel",
+    },
     relationships: {
       title: "Collaborative Tasks",
       subtitle: "Sessions and child agents dispatched by the main Agent",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -263,6 +263,8 @@ const zh = {
     uploadAttachment: "上传图片或附件",
     queuedCount: (count) => `待发送 ${count}`,
     queuedHint: "当前回复结束后将按顺序发送",
+    clearQueuedMessages: "清空待发送",
+    removeQueuedMessage: (index) => `删除第 ${index} 条待发送消息`,
     outline: "大纲",
     copyMessage: "复制消息文本",
     copiedMessage: "已复制消息",
@@ -290,6 +292,8 @@ const zh = {
     jumpToPreviousUserMessage: "定位到上一句",
     tabShortcutHint: (number) => `Cmd + ${number}`,
     tabSwitchTooltip: (number) => `Cmd + ${number} 切换到此会话`,
+    scrollTabsLeft: "向左滚动会话标签",
+    scrollTabsRight: "向右滚动会话标签",
     closeTab: "关闭会话",
     closeTabHint: "该操作不会清除会话内容，可再次打开",
     closeTabAriaLabel: (agent) => `关闭会话 ${agent}`,
@@ -297,6 +301,9 @@ const zh = {
   inspector: {
     title: "追踪与观察",
     subtitle: "当前会话的文件、摘要、运行记录与环境",
+    compact: {
+      closeSheet: "关闭追踪面板",
+    },
     relationships: {
       title: "协同任务",
       subtitle: "主 Agent 派发的会话与子 Agent",


### PR DESCRIPTION
## Summary
- fix the first-send composer clear edge case and keep prompt state in sync
- let users remove individual queued messages or clear the queued list before they send
- soften the empty composer placeholder styling and refresh related UI/tests
- carry forward the current command-center inspector/session overview polish in this branch

## Validation
- `npm test -- src/App.test.jsx`
- `npm test -- src/components/command-center/chat-panel.test.jsx`
- `npm test -- src/components/command-center/inspector-panel.test.jsx`