### PR TITLE
chore: update Tailwind packages to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@tailwindcss/vite": "^4.1.13",
+        "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -54,7 +54,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^28.1.0",
-        "tailwindcss": "^4.1.13",
+        "tailwindcss": "^4.2.1",
         "vite": "^7.1.3",
         "vitest": "^4.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@tailwindcss/vite": "^4.1.13",
+    "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -95,7 +95,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^28.1.0",
-    "tailwindcss": "^4.1.13",
+    "tailwindcss": "^4.2.1",
     "vite": "^7.1.3",
     "vitest": "^4.1.0"
   }


### PR DESCRIPTION
## Summary
- update `tailwindcss` to `4.2.1`
- update `@tailwindcss/vite` to `4.2.1`
- refresh the lockfile for the new Tailwind toolchain

## Testing
- npm run build
- npm run lint

## Notes
- `npm run lint` still reports the repository's existing React Hooks warnings, but no new errors were introduced by this update.